### PR TITLE
README: Ausführen des fertigen Containeres: Aufruf mit Option `-v /dev/shm:/dev/shm`, genauere Hinweise zu VNC-Cients

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007 siehe LICENCE.txt
 Die folgenden Umgebungsvariablen müssen/können in einer Datei env.txt liegen. Siehe env.example
 
 Ausführen des fertigen Containeres:
-```docker run -p 8080:80 --env-file env.txt ghcr.io/tiffel/impftermin```
+```docker run -p 8080:80 --env-file env.txt -v /dev/shm:/dev/shm ghcr.io/tiffel/impftermin```
+
+Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten. Für die Nutzung mit anderen VNC-Clients, siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
 
 ## Umgebungsvariablen
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Die folgenden Umgebungsvariablen müssen/können in einer Datei env.txt liegen. 
 Ausführen des fertigen Containeres:
 ```docker run -p 8080:80 --env-file env.txt -v /dev/shm:/dev/shm ghcr.io/tiffel/impftermin```
 
-Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten (Login mit Benutzername: root und Passwort:mysupersecretbrowserpassword). Für die Nutzung mit anderen VNC-Clients siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
+Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten (Login mit Benutzername: root und z. B. mit Passwort: mysupersecretbrowserpassword). Für die Nutzung mit anderen VNC-Clients siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
 
 ## Umgebungsvariablen
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Die folgenden Umgebungsvariablen müssen/können in einer Datei env.txt liegen. 
 Ausführen des fertigen Containeres:
 ```docker run -p 8080:80 --env-file env.txt -v /dev/shm:/dev/shm ghcr.io/tiffel/impftermin```
 
-Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten (Login mit z. B. root:mysupersecretbrowserpassword). Für die Nutzung mit anderen VNC-Clients siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
+Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten (Login mit Benutzername: root und Passwort:mysupersecretbrowserpassword). Für die Nutzung mit anderen VNC-Clients siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
 
 ## Umgebungsvariablen
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Die folgenden Umgebungsvariablen müssen/können in einer Datei env.txt liegen. 
 Ausführen des fertigen Containeres:
 ```docker run -p 8080:80 --env-file env.txt -v /dev/shm:/dev/shm ghcr.io/tiffel/impftermin```
 
-Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten. Für die Nutzung mit anderen VNC-Clients, siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
+Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten. Für die Nutzung mit anderen VNC-Clients siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
 
 ## Umgebungsvariablen
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Die folgenden Umgebungsvariablen müssen/können in einer Datei env.txt liegen. 
 Ausführen des fertigen Containeres:
 ```docker run -p 8080:80 --env-file env.txt -v /dev/shm:/dev/shm ghcr.io/tiffel/impftermin```
 
-Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten. Für die Nutzung mit anderen VNC-Clients siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
+Nach dem Start des Containers, geben Sie im Webbrowser [localhost:8080](http://localhost:8080) ein, um den noVNC VNC-Client zu starten (Login mit z. B. root:mysupersecretbrowserpassword). Für die Nutzung mit anderen VNC-Clients siehe [github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer](https://github.com/fcwu/docker-ubuntu-vnc-desktop#vnc-viewer).
 
 ## Umgebungsvariablen
 


### PR DESCRIPTION
1. Dem Docker-Aufruf das Argument `-v /dev/shm:/dev/shm` hinzugefügt, analog zu fcwu/docker-ubuntu-vnc-desktop@5e9ff11
2. Darunter genauere Hinweise zur Nutzung des VNC-Clients noVNC und Links für andere VNC-Clients hinzugefügt.